### PR TITLE
fix: 修正邮箱设置跳转路由

### DIFF
--- a/packages/ui/certd-client/src/router/source/modules/certd.ts
+++ b/packages/ui/certd-client/src/router/source/modules/certd.ts
@@ -61,8 +61,8 @@ export const certdResources = [
       // {
       //   title: "邮箱设置",
       //   name: "EmailSetting",
-      //   path: "/certd/settings/email",
-      //   component: "/certd/settings/email-setting.vue",
+      //   path: "/sys/settings/email",
+      //   component: "/sys/settings/email-setting.vue",
       //   meta: {
       //     icon: "ion:mail-outline",
       //     auth: true

--- a/packages/ui/certd-client/src/views/certd/pipeline/certd-form/crud.tsx
+++ b/packages/ui/certd-client/src/views/certd/pipeline/certd-form/crud.tsx
@@ -122,7 +122,7 @@ export default function (certPluginGroup: PluginGroup, formWrapperRef: any): Cre
                 }
                 return (
                   <div>
-                    需要配置<router-link to={{ path: "/certd/settings/email" }}>邮件服务器</router-link>才能发送邮件(专业版请忽略)
+                    需要配置<router-link to={{ path: "/sys/settings/email" }}>邮件服务器</router-link>才能发送邮件(专业版请忽略)
                   </div>
                 );
               }

--- a/packages/ui/certd-client/src/views/certd/pipeline/pipeline/component/notification-form/pi-notification-form-email.vue
+++ b/packages/ui/certd-client/src/views/certd/pipeline/pipeline/component/notification-form/pi-notification-form-email.vue
@@ -17,7 +17,7 @@
     />
 
     <a-alert v-if="!settingStore.isPlus" class="m-1" type="info">
-      <template #message> 还没有配置邮件服务器？<router-link :to="{ path: '/certd/settings/email' }">现在就去</router-link> </template>
+      <template #message> 还没有配置邮件服务器？<router-link :to="{ path: '/sys/settings/email' }">现在就去</router-link> </template>
     </a-alert>
   </div>
 </template>


### PR DESCRIPTION
编辑流水线页面的`现在就去`按钮的目标路由404。 
![image](https://github.com/user-attachments/assets/d29edb9a-b8bd-410e-928f-5f1b7b7c7c3c)

代码编辑内容：
- 将相关位置的`/certd/settings/email`修改为`/sys/settings/email`