### PR TITLE
发布镜像到 GitHub Packages

### DIFF
--- a/.github/workflows/build-image-for-test.yml
+++ b/.github/workflows/build-image-for-test.yml
@@ -10,6 +10,7 @@ on:
 #    - cron: '17 19 * * *'
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-certd-image:
@@ -61,6 +62,13 @@ jobs:
           username: ${{ secrets.aliyun_cs_username }}
           password: ${{ secrets.aliyun_cs_password }}
 
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -76,4 +84,5 @@ jobs:
           tags: |
             registry.cn-shenzhen.aliyuncs.com/handsfree/certd-dev:latest
             greper/certd-dev:latest
+            ghcr.io/${{ github.repository }}:dev-latest
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,7 @@ on:
 #    - cron: '17 19 * * *'
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-certd-image:
@@ -61,6 +62,13 @@ jobs:
           username: ${{ secrets.aliyun_cs_username }}
           password: ${{ secrets.aliyun_cs_password }}
 
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -78,7 +86,8 @@ jobs:
             registry.cn-shenzhen.aliyuncs.com/handsfree/certd:${{steps.get_certd_version.outputs.result}}
             greper/certd:latest
             greper/certd:${{steps.get_certd_version.outputs.result}}
-
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{steps.get_certd_version.outputs.result}}
 #      - name: Build armv7
 #        uses: docker/build-push-action@v6
 #        with:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ https://certd.handfree.work/
   * `https://hub.docker.com/r/greper/certd`
   * `greper/certd:latest`
   * `greper/certd:armv7`、`greper/certd:[version]-armv7`
+* GitHub Packages地址:
+  * `ghcr.io/certd/certd:latest`
 
 * 镜像构建通过`Actions`自动执行，过程公开透明，请放心使用
   * [点我查看镜像构建日志](https://github.com/certd/certd/actions/workflows/build-image.yml) 


### PR DESCRIPTION
Docker Hub 现在未认证每小时只能拉十个镜像. 添加了发布到 GitHub Packages 的 Pipeline (国内似乎可以访问)