### PR TITLE
fix: 修复腾讯云部署到任意资源插件，无法使用之前已上传的腾讯云证书问题

### DIFF
--- a/packages/ui/certd-server/src/plugins/plugin-tencent/plugin/deploy-to-all/index.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-tencent/plugin/deploy-to-all/index.ts
@@ -129,9 +129,9 @@ export class DeployCertToTencentAll extends AbstractTaskPlugin {
 
     let certId:string = null
     if (typeof this.tencentCertId === 'string') {
-      certId = this.tencentCertId;
+      certId = this.tencentCertId as string;
     } else if (this.tencentCertId && typeof this.tencentCertId === 'object') {
-      certId = await this.uploadToTencent(access, this.tencentCertId);
+      certId = await this.uploadToTencent(access, this.tencentCertId as CertInfo);
     } else {
       throw new Error('无效的证书输入类型');
     }

--- a/packages/ui/certd-server/src/plugins/plugin-tencent/plugin/deploy-to-all/index.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-tencent/plugin/deploy-to-all/index.ts
@@ -128,11 +128,12 @@ export class DeployCertToTencentAll extends AbstractTaskPlugin {
     });
 
     let certId:string = null
-    if (typeof certId === 'object') {
-      //上传
-      certId = await this.uploadToTencent(access,this.tencentCertId as CertInfo);
+    if (typeof this.tencentCertId === 'string') {
+      certId = this.tencentCertId;
+    } else if (this.tencentCertId && typeof this.tencentCertId === 'object') {
+      certId = await this.uploadToTencent(access, this.tencentCertId);
     } else {
-      certId = this.tencentCertId  as string;
+      throw new Error('无效的证书输入类型');
     }
 
     const params = {


### PR DESCRIPTION
fixed #368  引起的关联问题
我看了下你最新的修复，仍然是有问题的 
```
 let certId:string = null
    if (typeof certId === 'object') {
      //上传
      certId = await this.uploadToTencent(access,this.tencentCertId as CertInfo);
    } else {
      certId = this.tencentCertId  as string;
    }
```