### PR TITLE
Potential fix for code scanning alert no. 31: Incomplete string escaping or encoding

### DIFF
--- a/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.ts
+++ b/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.ts
@@ -461,7 +461,7 @@ export class PipelineService extends BaseService<PipelineEntity> {
       cron = cron.replace("* *", "0 0");
     }
     if (cron.startsWith("*")) {
-      cron = cron.replace("*", "0");
+      cron = cron.replace(/\*/g, "0");
     }
     const triggerId = trigger.id;
     const name = this.buildCronKey(pipelineId, triggerId);


### PR DESCRIPTION
Potential fix for [https://github.com/certd/certd/security/code-scanning/31](https://github.com/certd/certd/security/code-scanning/31)

To fix the problem, we should ensure that all occurrences of the asterisk character (`*`) in the cron string are replaced with `"0"` when the string starts with an asterisk. The best way to do this in JavaScript is to use a regular expression with the global flag (`/g`). Specifically, replace `cron.replace("*", "0")` with `cron.replace(/\*/g, "0")`. This change should be made only on line 464 of `packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.ts`. No additional imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
