### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/packages/ui/certd-server/test/plugins/51dns.test.mjs
+++ b/packages/ui/certd-server/test/plugins/51dns.test.mjs
@@ -54,7 +54,7 @@ async function login() {
     'redirectTo': 'https://www.51dns.com/domain',
     '_token': _token
   }
-  console.log(JSON.stringify(obj, null, 2))
+  // console.log(JSON.stringify(obj, null, 2)) // Avoid logging sensitive data
   const res2 = await instance.request({
     url: 'https://www.51dns.com/login',
     method: 'post',


### PR DESCRIPTION
Potential fix for [https://github.com/certd/certd/security/code-scanning/26](https://github.com/certd/certd/security/code-scanning/26)

To fix the problem, we should avoid logging sensitive information such as passwords or authentication tokens, even if they are encrypted. The best way to address this is to remove or redact the sensitive fields from the object before logging, or to avoid logging the object entirely if it contains sensitive data. In this case, since the log is for debugging, we can either remove the log statement or log only non-sensitive fields. The change should be made in `packages/ui/certd-server/test/plugins/51dns.test.mjs` at line 57, where `console.log(JSON.stringify(obj, null, 2))` is called. No new imports or methods are needed; simply remove or modify the log statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
