### PR TITLE
chore: add start:server npm script for quick server launch from root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "lerna bootstrap --hoist",
+    "start:server": "cd ./packages/ui/certd-server && npm start",
     "devb": "lerna run dev-build",
     "i-all": "lerna link && lerna exec npm install  ",
     "publish": "npm run prepublishOnly2  && lerna publish --force-publish=pro/plus-core --conventional-commits --create-release github && npm run afterpublishOnly && npm run commitAll",


### PR DESCRIPTION
用 start.sh 每次都要重新 build server，其实多数情况只要启动 server 就行了，没必要这么折腾。