### PR TITLE
docs: 更改中英文档跳转链接显示形式

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Certd
 
-[English](./README_en.md) | [中文](./README.md)
+中文 | [English](./README_en.md)
 
 Certd® 是一个免费的全自动证书管理系统，让你的网站证书永不过期。   
 后缀d取自linux守护进程的命名风格，意为证书守护进程

--- a/README_en.md
+++ b/README_en.md
@@ -1,6 +1,6 @@
 # Certd
 
-[English](./README_en.md) | [中文](./README.md)
+[中文](./README.md) | English
 
 Certd® is a free, fully automated certificate management system that ensures your website certificates never expire. The suffix 'd' is inspired by the naming convention of Linux daemons, representing a certificate daemon.
 


### PR DESCRIPTION
参考绝大多数开源项目，感觉这样好些，当前所在的文档就没必要加跳转的链接了