### PR TITLE
fix 站点IP监控提示权限不足

### DIFF
--- a/packages/ui/certd-client/src/views/certd/monitor/site/ip/index.vue
+++ b/packages/ui/certd-client/src/views/certd/monitor/site/ip/index.vue
@@ -8,7 +8,6 @@
 import { onActivated, onMounted, ref, Ref } from "vue";
 import { useFs } from "@fast-crud/fast-crud";
 import createCrudOptions from "./crud";
-import { siteIpApi } from "./api";
 
 defineOptions({
   name: "SiteIpCertMonitor",
@@ -21,11 +20,6 @@ const { crudBinding, crudRef, crudExpose } = useFs({
   context: {
     props,
   },
-});
-
-const siteInfoRef: Ref<any> = ref({});
-onMounted(async () => {
-  siteInfoRef.value = await siteIpApi.GetObj(props.siteId);
 });
 
 // 页面打开后获取列表数据


### PR DESCRIPTION
移除无意义的调用用以解决访问“站点证书监控 -> IP管理”时提示权限不足问题
<img width="771" height="719" alt="9a681fcf6b49329b0109e8d3f736d7d6" src="https://github.com/user-attachments/assets/821f2396-ea5b-40ec-85a3-a9181f761061" />
<img width="1327" height="840" alt="2d4b3f8e45987c0c721484898b734b8c" src="https://github.com/user-attachments/assets/256ee999-3565-4e2c-8647-0942aa61b8c9" />

