### PR TITLE
AWS ACM上传完整证书链

### DIFF
--- a/packages/ui/certd-server/src/plugins/plugin-aws/libs/aws-client.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-aws/libs/aws-client.ts
@@ -30,16 +30,23 @@ export class AwsClient {
       },
     });
 
-    const cert = certInfo.crt.split("-----END CERTIFICATE-----")[0] + "-----END CERTIFICATE-----";
+    // Split the full PEM chain: first block is the leaf cert, the rest is the intermediate chain
+    const pemBlocks = certInfo.crt.split(/(?<=-----END CERTIFICATE-----)/);
+    const cert = pemBlocks[0].trim();
+    const chain = pemBlocks
+      .slice(1)
+      .join("")
+      .trim();
+
     // 构建上传参数
     const data = await acmClient.send(
       new ImportCertificateCommand({
         Certificate: Buffer.from(cert),
         PrivateKey: Buffer.from(certInfo.key),
-        // CertificateChain: certificateChain, // 可选
+        CertificateChain: chain ? Buffer.from(chain) : undefined,
       })
     );
-    console.log("Upload successful:", data);
+    this.logger.info(`Upload successful: ${data.CertificateArn}`);
     // 返回证书 ARN（Amazon Resource Name）
     return data.CertificateArn;
   }


### PR DESCRIPTION
Split the PEM in certInfo.crt into a leaf certificate and intermediate chain (using a lookbehind regex), trim the blocks, and pass the chain to ImportCertificateCommand only when present. Replace console.log with this.logger.info and log the returned CertificateArn. This ensures the leaf cert is uploaded separately from its chain and avoids sending an empty CertificateChain.

Fix: #746 