### PR TITLE
fix(pipeline): propagate runtimeDepsService to access instances

### DIFF
--- a/packages/libs/lib-server/src/user/access/service/access-getter.ts
+++ b/packages/libs/lib-server/src/user/access/service/access-getter.ts
@@ -4,6 +4,7 @@ export class AccessGetter implements IAccessService {
   userId: number;
   projectId?: number;
   getter: <T>(id: any, userId?: number, projectId?: number, ignorePermission?: boolean) => Promise<T>;
+  runtimeDepsService?: any;
   constructor(userId: number, projectId: number, getter: (id: any, userId: number, projectId?: number, ignorePermission?: boolean) => Promise<any>) {
     this.userId = userId;
     this.projectId = projectId;

--- a/packages/libs/lib-server/src/user/access/service/access-service.ts
+++ b/packages/libs/lib-server/src/user/access/service/access-service.ts
@@ -20,6 +20,9 @@ export class AccessService extends BaseService<AccessEntity> {
   @Inject()
   encryptService: EncryptService;
 
+  @Inject("runtimeDepsService")
+  runtimeDepsService: any;
+
   @ApplicationContext()
   applicationContext: IMidwayContainer;
 
@@ -191,6 +194,7 @@ export class AccessService extends BaseService<AccessEntity> {
     const serviceGetter = taskServiceBuilder.create({ userId: userId || 0, projectId });
     const getAccessById = this.getById.bind(this);
     const accessGetter = new AccessGetter(userId, projectId, getAccessById);
+    accessGetter.runtimeDepsService = this.runtimeDepsService;
     const accessContext = {
       logger,
       http,


### PR DESCRIPTION
## What
Fixes runtimeDepsService not initialized error when executing task plugins and dns provider operations (e.g. Volcengine) under certain CNAME verification and pipeline scenarios by injecting runtimeDepsService into AccessService and passing it to AccessGetter.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #768