### PR TITLE
fix(pipeline): 校验定时触发器cron表达式，拦截2月31号等无效日期

### DIFF
--- a/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.test.ts
+++ b/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.test.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { ValidateException } from "@certd/lib-server";
 import { PipelineEntity } from "../entity/pipeline.js";
 import { PipelineService } from "./pipeline-service.js";
 
@@ -34,5 +35,52 @@ describe("PipelineService", () => {
     await service.doRun(entity, null, "ALL");
 
     assert.equal(historyStarted, false);
+  });
+
+  it("getCronNextTimes returns empty list for invalid cron such as Feb 31", () => {
+    const service = new PipelineService();
+    //2月31号：cron-parser会抛 Invalid explicit day of month definition
+    const nextTimes = service.getCronNextTimes("0 0 0 31 2 *", 1);
+    assert.deepEqual(nextTimes, []);
+  });
+
+  it("getCronNextTimes returns next time for valid cron", () => {
+    const service = new PipelineService();
+    //1月31号是合法日期
+    const nextTimes = service.getCronNextTimes("0 0 0 31 1 *", 1);
+    assert.equal(nextTimes.length, 1);
+  });
+
+  it("checkTriggers throws ValidateException for invalid cron such as Feb 31", () => {
+    const service = new PipelineService();
+    const pipeline: any = {
+      triggers: [{ id: "t1", type: "timer", props: { cron: "0 0 0 31 2 *" } }],
+    };
+    assert.throws(
+      () => (service as any).checkTriggers(pipeline),
+      (e: any) => e instanceof ValidateException
+    );
+  });
+
+  it("checkTriggers ignores non-timer triggers and empty cron", () => {
+    const service = new PipelineService();
+    const pipeline: any = {
+      triggers: [
+        { id: "t1", type: "webhook", props: { url: "http://example.com" } },
+        { id: "t2", type: "timer", props: {} },
+      ],
+    };
+    assert.doesNotThrow(() => (service as any).checkTriggers(pipeline));
+  });
+
+  it("checkTriggers passes for valid cron", () => {
+    const service = new PipelineService();
+    const pipeline: any = {
+      triggers: [
+        { id: "t1", type: "timer", props: { cron: "0 0 0 31 1 *" } },
+        { id: "t2", type: "timer", props: { cron: "0 0 0 * * *" } },
+      ],
+    };
+    assert.doesNotThrow(() => (service as any).checkTriggers(pipeline));
   });
 });

--- a/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.ts
+++ b/packages/ui/certd-server/src/modules/pipeline/service/pipeline-service.ts
@@ -157,10 +157,15 @@ export class PipelineService extends BaseService<PipelineEntity> {
       return [];
     }
     const nextTimes = [];
-    const interval = parser.parseExpression(cron);
-    for (let i = 0; i < count; i++) {
-      const next = interval.next().getTime();
-      nextTimes.push(dayjs(next).format("YYYY-MM-DD HH:mm:ss"));
+    try {
+      const interval = parser.parseExpression(cron);
+      for (let i = 0; i < count; i++) {
+        const next = interval.next().getTime();
+        nextTimes.push(dayjs(next).format("YYYY-MM-DD HH:mm:ss"));
+      }
+    } catch (e) {
+      //历史数据中可能存在无效的cron表达式（例如2月31号），这里容错，避免流水线列表接口报错
+      logger.warn(`cron表达式解析失败：${cron}`, e);
     }
     return nextTimes;
   }
@@ -296,6 +301,8 @@ export class PipelineService extends BaseService<PipelineEntity> {
    * @param pipeline
    */
   async doUpdatePipelineJson(bean: PipelineEntity, pipeline: Pipeline) {
+    //保存前校验定时触发器cron表达式，避免无效表达式（例如2月31号）入库后导致流水线列表加载和定时任务注册报错
+    this.checkTriggers(pipeline);
     await this.unregisterTriggers(bean);
     if (pipeline.title) {
       bean.title = pipeline.title;
@@ -313,6 +320,37 @@ export class PipelineService extends BaseService<PipelineEntity> {
     await this.addOrUpdate(bean);
     await this.registerTrigger(bean);
     return bean;
+  }
+
+  /**
+   * 校验流水线中所有定时触发器（timer）的cron表达式是否有效
+   * cron-parser无法解析的表达式（例如2月31号）会导致流水线列表加载和定时任务注册报错，保存前必须拦截
+   */
+  private checkTriggers(pipeline: Pipeline) {
+    if (pipeline.triggers == null) {
+      return;
+    }
+    for (const trigger of pipeline.triggers) {
+      if (trigger.type !== "timer") {
+        continue;
+      }
+      const cron = trigger.props?.cron;
+      if (cron == null || cron.trim() === "") {
+        continue;
+      }
+      this.checkCronExpression(cron);
+    }
+  }
+
+  /**
+   * 校验单个cron表达式是否可被cron-parser解析，不可解析时抛出友好错误
+   */
+  private checkCronExpression(cron: string) {
+    try {
+      parser.parseExpression(cron.trim());
+    } catch (e) {
+      throw new ValidateException(`定时触发cron表达式无效：${cron.trim()}，请检查日期是否正确（例如2月没有31号）`);
+    }
   }
 
   private async checkMaxPipelineCount(bean: PipelineEntity, pipeline: Pipeline, domains: string[], old?: PipelineEntity) {
@@ -543,6 +581,13 @@ export class PipelineService extends BaseService<PipelineEntity> {
     }
     if (cron.startsWith("* ")) {
       cron = "0 " + cron.substring(2);
+    }
+    //校验cron表达式有效性，无效（例如2月31号）时跳过注册，避免保存或启动时抛异常
+    try {
+      parser.parseExpression(cron);
+    } catch (e) {
+      logger.warn(`cron表达式无效，跳过定时任务注册：${cron}`, e);
+      return;
     }
     const triggerId = trigger.id;
     const name = this.buildCronKey(pipelineId, triggerId);


### PR DESCRIPTION
## 问题描述

添加流水线时，定时触发器可以保存 2月31号 这类不存在的日期（cron 表达式如 \