### PR TITLE
feat(plugin): add Fastly custom TLS certificates integration

### DIFF
--- a/packages/ui/certd-server/src/plugins/index.ts
+++ b/packages/ui/certd-server/src/plugins/index.ts
@@ -50,3 +50,4 @@
 // export * from './plugin-nginx-proxy-manager/index.js'
 // export * from './plugin-hipmdnsmgr/index.js'
 // export * from './plugin-dynadot/index.js'
+// export * from './plugin-fastly/index.js';

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/access.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/access.ts
@@ -1,0 +1,107 @@
+import { AccessInput, BaseAccess, IsAccess } from "@certd/pipeline";
+
+/**
+ * Fastly Access Plugin
+ * Provides API authentication and HTTP helper for Fastly API endpoints.
+ */
+@IsAccess({
+  name: "fastly",
+  title: "Fastly授权",
+  icon: "simple-icons:fastly",
+  desc: "Fastly CDN / TLS Custom Certificates API 授权",
+})
+export class FastlyAccess extends BaseAccess {
+  @AccessInput({
+    title: "API Token",
+    component: {
+      placeholder: "Fastly API Key / Token",
+    },
+    helper: "前往 Fastly Account Settings -> Personal Access Tokens 创建 Token",
+    required: true,
+    encrypt: true,
+  })
+  apiKey = "";
+
+  @AccessInput({
+    title: "HTTP代理",
+    component: {
+      placeholder: "http://xxxx.xxx.xx:10811",
+    },
+    helper: "可选：是否使用 HTTP 代理访问 Fastly API",
+    required: false,
+    encrypt: false,
+  })
+  proxy = "";
+
+  @AccessInput({
+    title: "测试",
+    component: {
+      name: "api-test",
+      action: "TestRequest",
+    },
+    helper: "测试授权是否正确",
+  })
+  testRequest = true;
+
+  async onTestRequest() {
+    await this.doRequestApi("/tls/certificates?page[size]=1", null, "get");
+    return "ok";
+  }
+
+  async doRequestApi(url: string, data: any = null, method = "post") {
+    const baseUrl = "https://api.fastly.com";
+    const requestUrl = url.startsWith("http") ? url : `${baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+
+    const headers: Record<string, string> = {
+      "Fastly-Key": this.apiKey,
+      Accept: "application/vnd.api+json",
+    };
+
+    if (data && (method.toLowerCase() === "post" || method.toLowerCase() === "patch" || method.toLowerCase() === "put")) {
+      headers["Content-Type"] = "application/vnd.api+json";
+    }
+
+    try {
+      const res = await this.ctx.http.request<any, any>({
+        url: requestUrl,
+        method,
+        headers,
+        data,
+        httpProxy: this.proxy,
+      });
+
+      return res;
+    } catch (e: any) {
+      const errorData = e.response?.data;
+      if (errorData) {
+        const errorsStr = JSON.stringify(errorData);
+        this.ctx.logger.error(`Fastly API Error: ${errorsStr}`);
+        throw new Error(`Fastly API 请求失败: ${errorsStr}`);
+      }
+      throw e;
+    }
+  }
+
+  async getServices() {
+    const res = await this.doRequestApi("/service", null, "get");
+    // /service returns a direct array of objects
+    return Array.isArray(res) ? res : res?.data || [];
+  }
+
+  async getTlsConfigurations() {
+    const res = await this.doRequestApi("/tls/configurations", null, "get");
+    return res?.data?.data || [];
+  }
+
+  async getTlsDomains() {
+    const res = await this.doRequestApi("/tls/domains", null, "get");
+    return res?.data?.data || [];
+  }
+
+  async getCertificates() {
+    const res = await this.doRequestApi("/tls/certificates", null, "get");
+    return res?.data?.data || [];
+  }
+}
+
+new FastlyAccess();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/access.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/access.ts
@@ -82,25 +82,47 @@ export class FastlyAccess extends BaseAccess {
     }
   }
 
+  /**
+   * Fetches every page of a Fastly JSON:API list endpoint.
+   * ctx.http already unwraps the response to its body, so the item array is at `body.data`.
+   * Fastly paginates these endpoints at 20 items/page by default; without looping only the
+   * first page would be visible in the selectors.
+   */
+  async listAllJsonApi(path: string, pageSize = 100): Promise<any[]> {
+    const all: any[] = [];
+    const maxPages = 100; // hard cap to avoid an infinite loop if the API misbehaves
+    for (let page = 1; page <= maxPages; page++) {
+      const sep = path.includes("?") ? "&" : "?";
+      const body = await this.doRequestApi(`${path}${sep}page[number]=${page}&page[size]=${pageSize}`, null, "get");
+      const items = body?.data;
+      if (!Array.isArray(items) || items.length === 0) {
+        break;
+      }
+      all.push(...items);
+      const totalPages = body?.meta?.total_pages;
+      if (totalPages != null ? page >= totalPages : items.length < pageSize) {
+        break;
+      }
+    }
+    return all;
+  }
+
   async getServices() {
-    const res = await this.doRequestApi("/service", null, "get");
-    // /service returns a direct array of objects
+    // legacy /service endpoint returns a bare array of objects (not JSON:API)
+    const res = await this.doRequestApi("/service?per_page=200", null, "get");
     return Array.isArray(res) ? res : res?.data || [];
   }
 
   async getTlsConfigurations() {
-    const res = await this.doRequestApi("/tls/configurations", null, "get");
-    return res?.data?.data || [];
+    return this.listAllJsonApi("/tls/configurations");
   }
 
   async getTlsDomains() {
-    const res = await this.doRequestApi("/tls/domains", null, "get");
-    return res?.data?.data || [];
+    return this.listAllJsonApi("/tls/domains");
   }
 
   async getCertificates() {
-    const res = await this.doRequestApi("/tls/certificates", null, "get");
-    return res?.data?.data || [];
+    return this.listAllJsonApi("/tls/certificates");
   }
 }
 

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/fastly.test.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/fastly.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { FastlyAccess } from "./access.js";
+import { FastlyUploadCertPlugin } from "./plugins/plugin-upload-cert.js";
+import { FastlyPurgeCachePlugin } from "./plugins/plugin-purge-cache.js";
+import { FastlyDeployCertPlugin } from "./plugins/plugin-deploy-to-service.js";
+import { FastlyRefreshCertPlugin } from "./plugins/plugin-refresh-cert.js";
+const mockCert = {
+  crt: "-----BEGIN CERTIFICATE-----\nMOCKCERT\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMOCKINTERMEDIATE\n-----END CERTIFICATE-----",
+  key: "-----BEGIN PRIVATE KEY-----\nMOCKKEY\n-----END PRIVATE KEY-----",
+};
+
+describe("FastlyAccess", () => {
+  it("should build correct request headers and URL for POST", async () => {
+    const access = new FastlyAccess();
+    access.apiKey = "test-fastly-key";
+
+    let capturedReq: any = null;
+    (access as any).ctx = {
+      http: {
+        request: async (req: any) => {
+          capturedReq = req;
+          return { data: { id: "tls_cert_123" } };
+        },
+      },
+      logger: { info: () => {}, error: () => {} },
+    };
+
+    const res = await access.doRequestApi("/tls/certificates", { test: true }, "post");
+
+    assert.equal(capturedReq.url, "https://api.fastly.com/tls/certificates");
+    assert.equal(capturedReq.headers["Fastly-Key"], "test-fastly-key");
+    assert.equal(capturedReq.headers["Accept"], "application/vnd.api+json");
+    assert.equal(capturedReq.headers["Content-Type"], "application/vnd.api+json");
+    assert.equal(res.data.id, "tls_cert_123");
+  });
+
+  it("should NOT set Content-Type for GET requests", async () => {
+    const access = new FastlyAccess();
+    access.apiKey = "test-key";
+
+    let capturedReq: any = null;
+    (access as any).ctx = {
+      http: {
+        request: async (req: any) => {
+          capturedReq = req;
+          return { data: [] };
+        },
+      },
+      logger: { info: () => {}, error: () => {} },
+    };
+
+    await access.doRequestApi("/tls/certificates?page[size]=1", null, "get");
+    assert.equal(capturedReq.headers["Content-Type"], undefined);
+    assert.equal(capturedReq.headers["Fastly-Key"], "test-key");
+  });
+
+  it("should pass proxy to http request when proxy is set", async () => {
+    const access = new FastlyAccess();
+    access.apiKey = "test-key";
+    access.proxy = "http://proxy.example.com:3128";
+
+    let capturedReq: any = null;
+    (access as any).ctx = {
+      http: {
+        request: async (req: any) => {
+          capturedReq = req;
+          return {};
+        },
+      },
+      logger: { info: () => {}, error: () => {} },
+    };
+
+    await access.doRequestApi("/tls/certificates", null, "get");
+    assert.equal(capturedReq.httpProxy, "http://proxy.example.com:3128");
+  });
+});
+
+describe("FastlyUploadCertPlugin - new certificate (2-step flow)", () => {
+  it("should upload private key first then create certificate with relationship", async () => {
+    const plugin = new FastlyUploadCertPlugin();
+    plugin.cert = mockCert as any;
+    plugin.accessId = "access-1";
+    plugin.name = "my-cert";
+
+    const calls: { path: string; payload: any; method: string }[] = [];
+
+    const mockAccess = {
+      doRequestApi: async (path: string, payload: any, method: string) => {
+        calls.push({ path, payload, method });
+        if (path === "/tls/private_keys") {
+          return { data: { id: "pk_abc123" } };
+        }
+        if (path === "/tls/certificates") {
+          return { data: { id: "tls_cert_new_999" } };
+        }
+        throw new Error(`Unexpected call: ${path}`);
+      },
+    };
+
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+
+    // Step 1: private key upload
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].path, "/tls/private_keys");
+    assert.equal(calls[0].method, "post");
+    assert.equal(calls[0].payload.data.type, "tls_private_key");
+    assert.equal(calls[0].payload.data.attributes.key, mockCert.key);
+    assert.equal(calls[0].payload.data.attributes.name, "my-cert");
+
+    // Step 2: certificate upload with relationship
+    assert.equal(calls[1].path, "/tls/certificates");
+    assert.equal(calls[1].method, "post");
+    assert.equal(calls[1].payload.data.type, "tls_certificate");
+    assert.equal(calls[1].payload.data.attributes.cert_blob, mockCert.crt);
+    assert.equal(calls[1].payload.data.relationships.tls_private_key.data.id, "pk_abc123");
+    assert.equal(calls[1].payload.data.relationships.tls_private_key.data.type, "tls_private_key");
+
+    assert.equal(plugin.fastlyCertId, "tls_cert_new_999");
+  });
+
+  it("should throw if private key upload returns no ID", async () => {
+    const plugin = new FastlyUploadCertPlugin();
+    plugin.cert = mockCert as any;
+    plugin.accessId = "access-1";
+
+    const mockAccess = {
+      doRequestApi: async () => ({ data: {} }), // no id returned
+    };
+
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await assert.rejects(
+      () => plugin.execute(),
+      /Fastly 私钥上传失败，未获取到 private key ID/
+    );
+  });
+});
+
+describe("FastlyUploadCertPlugin - update existing certificate (PATCH)", () => {
+  it("should PATCH existing certificate with only cert_blob, no private key step", async () => {
+    const plugin = new FastlyUploadCertPlugin();
+    plugin.cert = mockCert as any;
+    plugin.accessId = "access-1";
+    plugin.certificateId = "tls_cert_existing_123";
+    plugin.name = "updated-cert";
+
+    const calls: { path: string; payload: any; method: string }[] = [];
+
+    const mockAccess = {
+      doRequestApi: async (path: string, payload: any, method: string) => {
+        calls.push({ path, payload, method });
+        return { data: { id: "tls_cert_existing_123" } };
+      },
+    };
+
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+
+    // Only 1 API call for update
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].path, "/tls/certificates/tls_cert_existing_123");
+    assert.equal(calls[0].method, "patch");
+    assert.equal(calls[0].payload.data.type, "tls_certificate");
+    assert.equal(calls[0].payload.data.id, "tls_cert_existing_123");
+    assert.equal(calls[0].payload.data.attributes.cert_blob, mockCert.crt);
+    assert.equal(calls[0].payload.data.attributes.name, "updated-cert");
+    // No relationships on PATCH
+    assert.equal(calls[0].payload.data.relationships, undefined);
+
+    assert.equal(plugin.fastlyCertId, "tls_cert_existing_123");
+  });
+
+  it("should fallback fastlyCertId to certificateId when response has no id", async () => {
+    const plugin = new FastlyUploadCertPlugin();
+    plugin.cert = mockCert as any;
+    plugin.accessId = "access-1";
+    plugin.certificateId = "tls_cert_fallback_id";
+
+    const mockAccess = {
+      doRequestApi: async () => ({ data: {} }), // no id in response
+    };
+
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+    assert.equal(plugin.fastlyCertId, "tls_cert_fallback_id");
+  });
+});
+
+describe("FastlyPurgeCachePlugin", () => {
+  it("should call purge_all on the provided serviceId", async () => {
+    const plugin = new FastlyPurgeCachePlugin();
+    plugin.accessId = "access-1";
+    plugin.serviceId = "svc_123";
+
+    let capturedUrl = "";
+    let capturedMethod = "";
+    
+    const mockAccess = {
+      doRequestApi: async (path: string, payload: any, method: string) => {
+        capturedUrl = path;
+        capturedMethod = method;
+        return { data: { status: "ok" } };
+      }
+    };
+    
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+
+    assert.equal(capturedUrl, "/service/svc_123/purge_all");
+    assert.equal(capturedMethod, "post");
+  });
+});
+
+describe("FastlyDeployCertPlugin", () => {
+  it("should create tls_activation with correct relationships", async () => {
+    const plugin = new FastlyDeployCertPlugin();
+    plugin.accessId = "access-1";
+    plugin.certificateId = "cert_1";
+    plugin.domainId = "dom_1";
+    plugin.configurationId = "cfg_1";
+
+    let capturedPayload: any = null;
+    let capturedUrl = "";
+    
+    const mockAccess = {
+      doRequestApi: async (path: string, payload: any, method: string) => {
+        capturedUrl = path;
+        capturedPayload = payload;
+        return { data: { id: "act_123" } };
+      }
+    };
+    
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+
+    assert.equal(capturedUrl, "/tls/activations");
+    assert.equal(capturedPayload.data.type, "tls_activation");
+    assert.equal(capturedPayload.data.relationships.tls_certificate.data.id, "cert_1");
+    assert.equal(capturedPayload.data.relationships.tls_configuration.data.id, "cfg_1");
+    assert.equal(capturedPayload.data.relationships.tls_domain.data.id, "dom_1");
+  });
+});
+
+describe("FastlyRefreshCertPlugin", () => {
+  it("should update multiple certificates via PATCH", async () => {
+    const plugin = new FastlyRefreshCertPlugin();
+    plugin.cert = mockCert as any;
+    plugin.accessId = "access-1";
+    plugin.certList = ["cert_a", "cert_b"];
+
+    const calls: { path: string, payload: any }[] = [];
+    
+    const mockAccess = {
+      doRequestApi: async (path: string, payload: any, method: string) => {
+        calls.push({ path, payload });
+        return { data: { id: path.split('/').pop() } };
+      }
+    };
+    
+    (plugin as any).getAccess = async () => mockAccess;
+    (plugin as any).logger = { info: () => {}, error: () => {} };
+
+    await plugin.execute();
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].path, "/tls/certificates/cert_a");
+    assert.equal(calls[0].payload.data.id, "cert_a");
+    assert.equal(calls[0].payload.data.attributes.cert_blob, mockCert.crt);
+
+    assert.equal(calls[1].path, "/tls/certificates/cert_b");
+    assert.equal(calls[1].payload.data.id, "cert_b");
+  });
+});

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/fastly.test.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/fastly.test.ts
@@ -75,6 +75,59 @@ describe("FastlyAccess", () => {
   });
 });
 
+describe("FastlyAccess list helpers", () => {
+  function mockAccess(handler: (url: string) => any) {
+    const access = new FastlyAccess();
+    access.apiKey = "k";
+    (access as any).ctx = {
+      http: { request: async (req: any) => handler(req.url) },
+      logger: { info: () => {}, error: () => {} },
+    };
+    return access;
+  }
+
+  it("getCertificates returns body.data (not body.data.data) and aggregates all pages", async () => {
+    const urls: string[] = [];
+    const access = mockAccess((url: string) => {
+      urls.push(url);
+      const page = Number(url.match(/page\[number\]=(\d+)/)?.[1]);
+      // 3 pages total, 2 items each
+      const pageItems = [
+        [{ id: "c1" }, { id: "c2" }],
+        [{ id: "c3" }, { id: "c4" }],
+        [{ id: "c5" }, { id: "c6" }],
+      ];
+      return { data: pageItems[page - 1] ?? [], meta: { total_pages: 3 } };
+    });
+
+    const list = await access.getCertificates();
+    assert.deepEqual(
+      list.map((x: any) => x.id),
+      ["c1", "c2", "c3", "c4", "c5", "c6"]
+    );
+    assert.equal(urls.length, 3);
+  });
+
+  it("stops paginating on a short page when total_pages is absent", async () => {
+    let calls = 0;
+    const access = mockAccess(() => {
+      calls++;
+      // single short page (< pageSize) => no more requests
+      return { data: [{ id: "d1" }] };
+    });
+
+    const list = await access.getTlsDomains();
+    assert.deepEqual(list, [{ id: "d1" }]);
+    assert.equal(calls, 1);
+  });
+
+  it("getServices unwraps a bare array response", async () => {
+    const access = mockAccess(() => [{ id: "svc1", name: "a" }]);
+    const list = await access.getServices();
+    assert.deepEqual(list, [{ id: "svc1", name: "a" }]);
+  });
+});
+
 describe("FastlyUploadCertPlugin - new certificate (2-step flow)", () => {
   it("should upload private key first then create certificate with relationship", async () => {
     const plugin = new FastlyUploadCertPlugin();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/index.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/index.ts
@@ -1,0 +1,2 @@
+export * from "./access.js";
+export * from "./plugins/index.js";

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/index.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/index.ts
@@ -1,0 +1,4 @@
+export * from "./plugin-upload-cert.js";
+export * from "./plugin-purge-cache.js";
+export * from "./plugin-deploy-to-service.js";
+export * from "./plugin-refresh-cert.js";

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-deploy-to-service.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-deploy-to-service.ts
@@ -1,0 +1,142 @@
+import { AbstractTaskPlugin, IsTaskPlugin, pluginGroups, RunStrategy, TaskInput } from "@certd/pipeline";
+import { createRemoteSelectInputDefine } from "@certd/plugin-lib";
+import { FastlyAccess } from "../access.js";
+
+@IsTaskPlugin({
+  name: "FastlyDeployCert",
+  title: "Fastly-部署TLS激活",
+  desc: "部署 Fastly 证书 (创建 TLS Activation 绑定证书到域名)",
+  icon: "simple-icons:fastly",
+  group: pluginGroups.cdn.key,
+  default: {
+    strategy: {
+      runStrategy: RunStrategy.SkipWhenSucceed,
+    },
+  },
+})
+export class FastlyDeployCertPlugin extends AbstractTaskPlugin {
+  @TaskInput({
+    title: "Access授权",
+    helper: "Fastly 授权凭证",
+    component: {
+      name: "access-selector",
+      type: "fastly",
+    },
+    required: true,
+  })
+  accessId!: string;
+
+  @TaskInput({
+    title: "证书ID",
+    helper: "要部署的 Fastly 证书ID。如果是前置任务上传的，可以在前置任务的高级设置中获取输出变量",
+    component: {
+      placeholder: "例如: tls_cert_xxx 或填入变量",
+    },
+    required: true,
+  })
+  certificateId!: string;
+
+  @TaskInput(
+    createRemoteSelectInputDefine({
+      title: "TLS 域名",
+      helper: "选择要绑定证书的 Fastly TLS 域名",
+      action: FastlyDeployCertPlugin.prototype.onGetTlsDomainList.name,
+      pager: false,
+      search: false,
+      required: true,
+    })
+  )
+  domainId!: string;
+
+  @TaskInput(
+    createRemoteSelectInputDefine({
+      title: "TLS 配置",
+      helper: "选择关联的 TLS 配置",
+      action: FastlyDeployCertPlugin.prototype.onGetTlsConfigurationList.name,
+      pager: false,
+      search: false,
+      required: true,
+    })
+  )
+  configurationId!: string;
+
+  async onInstance() {}
+
+  async execute(): Promise<void> {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+
+    if (!this.certificateId || !this.domainId || !this.configurationId) {
+      throw new Error("请提供完整的证书ID、TLS域名ID和TLS配置ID");
+    }
+
+    this.logger.info(`开始部署 Fastly TLS 激活 (域名ID: ${this.domainId})...`);
+
+    const payload: any = {
+      data: {
+        type: "tls_activation",
+        relationships: {
+          tls_certificate: {
+            data: {
+              type: "tls_certificate",
+              id: this.certificateId,
+            },
+          },
+          tls_configuration: {
+            data: {
+              type: "tls_configuration",
+              id: this.configurationId,
+            },
+          },
+          tls_domain: {
+            data: {
+              type: "tls_domain",
+              id: this.domainId,
+            },
+          },
+        },
+      },
+    };
+
+    const res = await access.doRequestApi("/tls/activations", payload, "post");
+    this.logger.info(`Fastly TLS 激活部署成功, 激活ID: ${res?.data?.id}`);
+  }
+
+  async onGetTlsDomainList() {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+    const list = await access.getTlsDomains();
+
+    if (!list || list.length === 0) {
+      return { list: [] };
+    }
+
+    const options = list.map((item: any) => {
+      // Fastly API typically returns id as the domain name for tls_domains
+      return {
+        label: item.id,
+        value: item.id,
+      };
+    });
+
+    return { list: options };
+  }
+
+  async onGetTlsConfigurationList() {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+    const list = await access.getTlsConfigurations();
+
+    if (!list || list.length === 0) {
+      return { list: [] };
+    }
+
+    const options = list.map((item: any) => {
+      return {
+        label: `${item.attributes?.name || "Unnamed Configuration"} (${item.id})`,
+        value: item.id,
+      };
+    });
+
+    return { list: options };
+  }
+}
+
+new FastlyDeployCertPlugin();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-purge-cache.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-purge-cache.ts
@@ -48,11 +48,9 @@ export class FastlyPurgeCachePlugin extends AbstractTaskPlugin {
     }
 
     this.logger.info(`开始清理 Fastly 服务 [${this.serviceId}] 的所有缓存...`);
-    
-    // POST /service/{service_id}/purge_all
-    await access.doRequestApi(`/service/${this.serviceId}/purge_all`, {
-      // empty body is acceptable for this endpoint, Fastly uses headers for auth
-    }, "post");
+
+    // POST /service/{service_id}/purge_all — no body; auth is via the Fastly-Key header
+    await access.doRequestApi(`/service/${this.serviceId}/purge_all`, null, "post");
 
     this.logger.info(`清理 Fastly 服务 [${this.serviceId}] 缓存成功`);
   }

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-purge-cache.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-purge-cache.ts
@@ -1,0 +1,79 @@
+import { AbstractTaskPlugin, IsTaskPlugin, pluginGroups, RunStrategy, TaskInput } from "@certd/pipeline";
+import { createRemoteSelectInputDefine } from "@certd/plugin-lib";
+import { FastlyAccess } from "../access.js";
+
+@IsTaskPlugin({
+  name: "FastlyPurgeCache",
+  title: "Fastly-清除缓存",
+  desc: "清除 Fastly 指定 Service 的所有缓存 (Purge All)",
+  icon: "simple-icons:fastly",
+  group: pluginGroups.cdn.key,
+  default: {
+    strategy: {
+      runStrategy: RunStrategy.SkipWhenSucceed,
+    },
+  },
+})
+export class FastlyPurgeCachePlugin extends AbstractTaskPlugin {
+  @TaskInput({
+    title: "Access授权",
+    helper: "Fastly 授权凭证",
+    component: {
+      name: "access-selector",
+      type: "fastly",
+    },
+    required: true,
+  })
+  accessId!: string;
+
+  @TaskInput(
+    createRemoteSelectInputDefine({
+      title: "Service (服务)",
+      helper: "选择要清理所有缓存的 Fastly 服务",
+      action: FastlyPurgeCachePlugin.prototype.onGetServiceList.name,
+      pager: false,
+      search: false,
+      required: true,
+    })
+  )
+  serviceId!: string;
+
+  async onInstance() {}
+
+  async execute(): Promise<void> {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+
+    if (!this.serviceId) {
+      throw new Error("请选择要清理缓存的 Service");
+    }
+
+    this.logger.info(`开始清理 Fastly 服务 [${this.serviceId}] 的所有缓存...`);
+    
+    // POST /service/{service_id}/purge_all
+    await access.doRequestApi(`/service/${this.serviceId}/purge_all`, {
+      // empty body is acceptable for this endpoint, Fastly uses headers for auth
+    }, "post");
+
+    this.logger.info(`清理 Fastly 服务 [${this.serviceId}] 缓存成功`);
+  }
+
+  async onGetServiceList() {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+    const services = await access.getServices();
+
+    if (!services || services.length === 0) {
+      return { list: [] };
+    }
+
+    const options = services.map((item: any) => {
+      return {
+        label: `${item.name} (${item.id})`,
+        value: item.id,
+      };
+    });
+
+    return { list: options };
+  }
+}
+
+new FastlyPurgeCachePlugin();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
@@ -41,7 +41,9 @@ export class FastlyRefreshCertPlugin extends AbstractTaskPlugin {
   @TaskInput(
     createRemoteSelectInputDefine({
       title: "证书列表",
-      helper: "选择要更新的 Fastly 证书 (必须是已存在的自定义证书)",
+      helper:
+        "选择要更新的 Fastly 证书 (必须是已存在的自定义证书)。" +
+        "注意：Fastly 要求更新后的证书与原证书使用相同私钥，请确保续期时复用私钥(reuse key)，否则更新会失败。",
       action: FastlyRefreshCertPlugin.prototype.onGetCertList.name,
       pager: false,
       search: false,

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
@@ -45,7 +45,6 @@ export class FastlyRefreshCertPlugin extends AbstractTaskPlugin {
       action: FastlyRefreshCertPlugin.prototype.onGetCertList.name,
       pager: false,
       search: false,
-      multiple: true,
       required: true,
     })
   )

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-refresh-cert.ts
@@ -1,0 +1,105 @@
+import { AbstractTaskPlugin, IsTaskPlugin, pluginGroups, RunStrategy, TaskInput } from "@certd/pipeline";
+import { CertApplyPluginNames, CertInfo } from "@certd/plugin-cert";
+import { createRemoteSelectInputDefine } from "@certd/plugin-lib";
+import { FastlyAccess } from "../access.js";
+
+@IsTaskPlugin({
+  name: "FastlyRefreshCert",
+  title: "Fastly-更新证书",
+  desc: "自动更新 Fastly CDN 上的已有自定义证书",
+  icon: "simple-icons:fastly",
+  group: pluginGroups.cdn.key,
+  default: {
+    strategy: {
+      runStrategy: RunStrategy.SkipWhenSucceed,
+    },
+  },
+})
+export class FastlyRefreshCertPlugin extends AbstractTaskPlugin {
+  @TaskInput({
+    title: "域名证书",
+    helper: "请选择前置任务输出的域名证书",
+    component: {
+      name: "output-selector",
+      from: [...CertApplyPluginNames],
+    },
+    required: true,
+  })
+  cert!: CertInfo;
+
+  @TaskInput({
+    title: "Access授权",
+    helper: "Fastly 授权凭证",
+    component: {
+      name: "access-selector",
+      type: "fastly",
+    },
+    required: true,
+  })
+  accessId!: string;
+
+  @TaskInput(
+    createRemoteSelectInputDefine({
+      title: "证书列表",
+      helper: "选择要更新的 Fastly 证书 (必须是已存在的自定义证书)",
+      action: FastlyRefreshCertPlugin.prototype.onGetCertList.name,
+      pager: false,
+      search: false,
+      multiple: true,
+      required: true,
+    })
+  )
+  certList!: string[];
+
+  async onInstance() {}
+
+  async execute(): Promise<void> {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+    const certPem = this.cert.crt;
+
+    if (!this.certList || this.certList.length === 0) {
+      throw new Error("请至少选择一个要更新的证书");
+    }
+
+    for (const certId of this.certList) {
+      this.logger.info(`----------- 开始更新 Fastly 证书：${certId} -----------`);
+
+      const payload: any = {
+        data: {
+          type: "tls_certificate",
+          id: certId,
+          attributes: {
+            cert_blob: certPem,
+          },
+        },
+      };
+
+      await access.doRequestApi(`/tls/certificates/${certId}`, payload, "patch");
+      this.logger.info(`----------- 更新 Fastly 证书 ${certId} 成功 -----------`);
+    }
+
+    this.logger.info("Fastly 证书批量更新完成");
+  }
+
+  async onGetCertList() {
+    const access = (await this.getAccess(this.accessId)) as FastlyAccess;
+    const list = await access.getCertificates();
+
+    if (!list || list.length === 0) {
+      throw new Error("没有找到 Fastly 证书");
+    }
+
+    const options = list.map((item: any) => {
+      const name = item.attributes?.name || "Unnamed";
+      const issuedTo = item.attributes?.issued_to || "Unknown Domain";
+      return {
+        label: `${name} - ${issuedTo} (${item.id})`,
+        value: item.id,
+      };
+    });
+
+    return { list: options };
+  }
+}
+
+new FastlyRefreshCertPlugin();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-upload-cert.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-upload-cert.ts
@@ -1,0 +1,145 @@
+import { AbstractTaskPlugin, IsTaskPlugin, pluginGroups, RunStrategy, TaskInput, TaskOutput } from "@certd/pipeline";
+import { CertApplyPluginNames, CertInfo } from "@certd/plugin-cert";
+import { FastlyAccess } from "../access.js";
+
+@IsTaskPlugin({
+  name: "FastlyUploadCert",
+  title: "Fastly-上传证书到Fastly",
+  desc: "部署 / 上传 SSL/TLS 自定义证书到 Fastly CDN",
+  icon: "simple-icons:fastly",
+  group: pluginGroups.cdn.key,
+  default: {
+    strategy: {
+      runStrategy: RunStrategy.SkipWhenSucceed,
+    },
+  },
+})
+export class FastlyUploadCertPlugin extends AbstractTaskPlugin {
+  @TaskInput({
+    title: "域名证书",
+    helper: "请选择前置任务输出的域名证书",
+    component: {
+      name: "output-selector",
+      from: [...CertApplyPluginNames],
+    },
+    required: true,
+  })
+  cert!: CertInfo;
+
+  @TaskInput({
+    title: "Access授权",
+    helper: "Fastly 授权凭证",
+    component: {
+      name: "access-selector",
+      type: "fastly",
+    },
+    required: true,
+  })
+  accessId!: string;
+
+  @TaskInput({
+    title: "证书ID (tls_certificate_id)",
+    helper: "可选。若填写则对 Fastly 已有证书进行更新(PATCH)；留空则新建上传(POST)",
+    component: {
+      placeholder: "例如: tls_cert_xxx (留空表示新建)",
+    },
+    required: false,
+  })
+  certificateId = "";
+
+  @TaskInput({
+    title: "证书名称",
+    helper: "可选。上传到 Fastly 上的自定义证书名称/标签",
+    component: {
+      placeholder: "例如: my-fastly-cert",
+    },
+    required: false,
+  })
+  name = "";
+
+  @TaskOutput({
+    title: "Fastly 证书 ID",
+  })
+  fastlyCertId = "";
+
+  async onInstance() {}
+
+  async execute(): Promise<void> {
+    const { cert, accessId, certificateId, name } = this;
+    const access = (await this.getAccess(accessId)) as FastlyAccess;
+
+    // cert.crt is the full certificate chain (PEM); cert.key is the private key (PEM)
+    const certPem = cert.crt;
+    const keyPem = cert.key;
+
+    const certName = name && name.trim() ? name.trim() : undefined;
+
+    if (certificateId && certificateId.trim()) {
+      // --- UPDATE existing certificate (PATCH) ---
+      // Only cert_blob is needed; private key is already linked to the certificate.
+      const targetId = certificateId.trim();
+      this.logger.info(`开始更新 Fastly 证书 [${targetId}]...`);
+
+      const payload: any = {
+        data: {
+          type: "tls_certificate",
+          id: targetId,
+          attributes: {
+            cert_blob: certPem,
+            ...(certName && { name: certName }),
+          },
+        },
+      };
+
+      const res = await access.doRequestApi(`/tls/certificates/${targetId}`, payload, "patch");
+      this.fastlyCertId = res?.data?.id || targetId;
+      this.logger.info(`Fastly 证书更新成功, ID: ${this.fastlyCertId}`);
+    } else {
+      // --- CREATE new certificate (2-step: upload private key first, then cert) ---
+      // Step 1: Upload the private key to /tls/private_keys
+      this.logger.info("开始上传私钥到 Fastly...");
+      const keyPayload: any = {
+        data: {
+          type: "tls_private_key",
+          attributes: {
+            key: keyPem,
+            ...(certName && { name: certName }),
+          },
+        },
+      };
+
+      const keyRes = await access.doRequestApi("/tls/private_keys", keyPayload, "post");
+      const privateKeyId = keyRes?.data?.id;
+      if (!privateKeyId) {
+        throw new Error("Fastly 私钥上传失败，未获取到 private key ID");
+      }
+      this.logger.info(`Fastly 私钥上传成功, privateKeyId: ${privateKeyId}`);
+
+      // Step 2: Upload the certificate referencing the private key
+      this.logger.info("开始上传证书到 Fastly...");
+      const certPayload: any = {
+        data: {
+          type: "tls_certificate",
+          attributes: {
+            cert_blob: certPem,
+            ...(certName && { name: certName }),
+          },
+          relationships: {
+            tls_private_key: {
+              data: {
+                type: "tls_private_key",
+                id: privateKeyId,
+              },
+            },
+          },
+        },
+      };
+
+      const certRes = await access.doRequestApi("/tls/certificates", certPayload, "post");
+      this.fastlyCertId = certRes?.data?.id || "";
+      this.logger.info(`Fastly 证书新建成功, ID: ${this.fastlyCertId}`);
+    }
+  }
+}
+
+new FastlyUploadCertPlugin();

--- a/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-upload-cert.ts
+++ b/packages/ui/certd-server/src/plugins/plugin-fastly/plugins/plugin-upload-cert.ts
@@ -39,7 +39,9 @@ export class FastlyUploadCertPlugin extends AbstractTaskPlugin {
 
   @TaskInput({
     title: "证书ID (tls_certificate_id)",
-    helper: "可选。若填写则对 Fastly 已有证书进行更新(PATCH)；留空则新建上传(POST)",
+    helper:
+      "可选。若填写则对 Fastly 已有证书进行更新(PATCH)；留空则新建上传(POST)。" +
+      "注意：Fastly 更新证书要求新证书与原证书使用相同的私钥，请确保续期时复用私钥(reuse key)，否则更新会失败。",
     component: {
       placeholder: "例如: tls_cert_xxx (留空表示新建)",
     },


### PR DESCRIPTION
Introduces a complete set of Fastly plugins for automating custom TLS certificates deployment:
- `FastlyAccess`: Handles Fastly API authentication and provides helpers for dynamic data fetching (Services, Domains, Configs).
- `FastlyUploadCert`: Uploads a new private key and certificate (2-step POST process) or updates an existing one (PATCH).
- `FastlyDeployCert`: Activates a custom TLS certificate by linking it to a TLS configuration and domain via TLS Activations API.
- `FastlyRefreshCert`: Bulk updates existing custom TLS certificates.
- `FastlyPurgeCache`: Purges all cache for a specified Fastly Service.

Includes comprehensive unit tests covering API request formats and error handling for all tasks.

Resolve #787 